### PR TITLE
Add listReviews()

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,19 @@ ghauth(authOptions, function (err, authData) {
 })
 ```
 
-There is also a `ghpulls.listComments(auth, org, repo, num, options, callback)` API for review comments, currently doesn't seem like the end-point is quite complete, however.
+## API
+
+### list(auth, org, repo[, options], callback)
+
+List pull requests for an org/user and repo combination
+
+### listComments(auth, org, repo, prNumber[, options], callback)
+
+List pull request _review_ comments for a given pull request number. ***This currently doesn't seem to work as the review API is still under development.***
+
+### listReviews(auth, org, repo, prNumber[, options], callback)
+
+List reviews for a given pull request number. This uses the experimental GitHub reviews API and is not guaranteed to continue to work properly! It's being enabled with a special development header that opts ghpulls in to this functionality. Caveat emptor!
 
 ## License
 

--- a/ghpulls.js
+++ b/ghpulls.js
@@ -1,6 +1,6 @@
 const ghutils = require('ghutils')
 
-module.exports.list = function list (auth, org, repo, options, callback) {
+function list (auth, org, repo, options, callback) {
   if (typeof options == 'function') {
     callback = options
     options  = {}
@@ -18,7 +18,27 @@ function listComments (auth, org, repo, num, options, callback) {
   }
 
   var url = 'https://api.github.com/repos/' + org + '/' + repo + '/pulls/' + num + '/comments?page=1'
+
   ghutils.lister(auth, url, options, callback)
 }
 
+
+function listReviews (auth, org, repo, num, options, callback) {
+  if (typeof options == 'function') {
+    callback = options
+    options  = {}
+  }
+
+  var url = 'https://api.github.com/repos/' + org + '/' + repo + '/pulls/' + num + '/reviews?page=1'
+
+  if (typeof options.headers != 'object')
+    options.headers = {}
+  options.headers.accept = 'application/vnd.github.black-cat-preview+json'
+
+  ghutils.lister(auth, url, options, callback)
+}
+
+
+module.exports.list         = list
 module.exports.listComments = listComments
+module.exports.listReviews  = listReviews

--- a/package.json
+++ b/package.json
@@ -24,11 +24,11 @@
     "ghutils": "~3.2.1"
   },
   "devDependencies": {
-    "bl": "~1.0.0",
+    "bl": "~1.2.0",
     "faucet": "0.0.1",
-    "hyperquest": "~1.2.0",
+    "hyperquest": "~2.1.2",
     "require-subvert": "~0.1.0",
-    "tape": "~4.2.2",
+    "tape": "~4.6.3",
     "xtend": "~4.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,11 +21,11 @@
   },
   "homepage": "https://github.com/rvagg/ghpulls",
   "dependencies": {
-    "ghutils": "~3.2.1"
+    "ghutils": "~3.3.0"
   },
   "devDependencies": {
     "bl": "~1.2.0",
-    "faucet": "0.0.1",
+    "faucet": "~0.0.1",
     "hyperquest": "~2.1.2",
     "require-subvert": "~0.1.0",
     "tape": "~4.6.3",

--- a/test.js
+++ b/test.js
@@ -150,3 +150,35 @@ test('test list multi-page pulls, options.afterDate includes partial', function 
     ]))
     .on('close'  , ghutils.verifyClose(t))
 })
+
+
+test('test list reviews', function (t) {
+  t.plan(8)
+
+  var auth     = { user: 'authuser', token: 'authtoken' }
+    , org      = 'testorg'
+    , repo     = 'testrepo'
+    , testData = [
+          {
+              response : [ { test1: 'data1' }, { test2: 'data2' } ]
+            , headers  : { } // no Link header, yet, apparently, so single page
+          }
+        //, { response: [] }
+      ]
+    , server
+
+  server = ghutils.makeServer(testData)
+    .on('ready', function () {
+      ghpulls.listReviews(xtend(auth), org, repo, 1234, ghutils.verifyData(t, testData[0].response))
+    })
+    .on('request', ghutils.verifyRequest(t, auth))
+    .on('request', function (request) {
+      // development header
+      t.equal(request.headers.accept, 'application/vnd.github.black-cat-preview+json')
+    })
+    .on('get', ghutils.verifyUrl(t, [
+        'https://api.github.com/repos/testorg/testrepo/pulls/1234/reviews?page=1'
+      //, 'https://api.github.com/repos/testorg/testrepo/pulls/1234/reviews?page=2'
+    ]))
+    .on('close'  , ghutils.verifyClose(t))
+})


### PR DESCRIPTION
Uses the https://developer.github.com/v3/pulls/reviews/ which is opt-in via `Accept` header as per https://developer.github.com/changes/2016-12-14-reviews-api/

Depends on https://github.com/rvagg/ghutils/pull/13 landing and bumping semver-minor of ghutils.

